### PR TITLE
Код отформатирован и исправлен баг при создании процессора через IoC

### DIFF
--- a/appserver/core.tests/IocTests.cs
+++ b/appserver/core.tests/IocTests.cs
@@ -9,14 +9,14 @@ namespace AppServer
 
             Ioc.Resolve<ICommand>(
                 "Update Ioc Resolve Dependency Strategy",
-                (Func<string, object[], object> args) => 
+                (Func<string, object[], object> args) =>
                 {
                     wasCalled = true;
                     return args;
                 }
             ).Execute();
 
-            Assert.True( wasCalled );
+            Assert.True(wasCalled);
         }
 
         [Fact]

--- a/appserver/core/Ioc.cs
+++ b/appserver/core/Ioc.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace AppServer
+﻿namespace AppServer
 {
     /// <summary>
     /// Контейнер инверсии зависимотей (Расширяемая фабрика).
@@ -8,12 +6,12 @@ namespace AppServer
     public class Ioc
     {
         internal static Func<string, object[], object> _strategy =
-            (string dependency, object[]args) =>
+            (string dependency, object[] args) =>
             {
                 if ("Update Ioc Resolve Dependency Strategy" == dependency)
                 {
                     return new AppServer.Impl.UpdateIocResolveDependencyStrategyCommand(
-                      (Func < Func<string, object[], object>, Func<string, object[], object> >) args[0]
+                      (Func<Func<string, object[], object>, Func<string, object[], object>>)args[0]
                     );
                 }
                 else
@@ -45,7 +43,7 @@ namespace AppServer
         /// </returns>
         public static T Resolve<T>(string dependency, params object[] args)
         {
-            return (T) _strategy(dependency, args);
+            return (T)_strategy(dependency, args);
         }
     }
 }

--- a/appserver/core/impl/UpdateIocResolveDependencyStrategyCommand.cs
+++ b/appserver/core/impl/UpdateIocResolveDependencyStrategyCommand.cs
@@ -6,7 +6,10 @@
 
         public UpdateIocResolveDependencyStrategyCommand(
             Func<Func<string, object[], object>, Func<string, object[], object>> updater
-        ) => _updateIoCStrategy = updater;
+        )
+        {
+            _updateIoCStrategy = updater;
+        }
 
         public void Execute()
         {

--- a/appserver/scopes.tests/ScopesTests.cs
+++ b/appserver/scopes.tests/ScopesTests.cs
@@ -2,8 +2,8 @@ namespace AppServer.Scopes
 {
     public class Tests : IDisposable
     {
-        public Tests() 
-        { 
+        public Tests()
+        {
             new InitCommand().Execute();
             var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
             Ioc.Resolve<ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
@@ -12,7 +12,7 @@ namespace AppServer.Scopes
         [Fact]
         public void Ioc_Should_Resolve_Registered_Dependency_In_CurrentScope()
         {
-            Ioc.Resolve<ICommand>("IoC.Register", "someDependency", (object[] args) => (object) 1).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "someDependency", (object[] args) => (object)1).Execute();
 
             Assert.Equal(1, Ioc.Resolve<int>("someDependency"));
         }
@@ -26,7 +26,7 @@ namespace AppServer.Scopes
         [Fact]
         public void Ioc_Should_Use_Parent_Scope_If_Resolving_Dependency_Is_Not_Defined_In_Current_Scope()
         {
-            Ioc.Resolve<ICommand>("IoC.Register", "someDependency", (object[] args) => (object) 1).Execute();
+            Ioc.Resolve<ICommand>("IoC.Register", "someDependency", (object[] args) => (object)1).Execute();
 
             var parentIoCScope = Ioc.Resolve<object>("IoC.Scope.Current");
 

--- a/appserver/scopes/DependencyResolver.cs
+++ b/appserver/scopes/DependencyResolver.cs
@@ -4,7 +4,10 @@
     {
         IDictionary<string, Func<object[], object>> _dependencies;
 
-        public DependencyResolver(object scope) => _dependencies = (IDictionary<string, Func<object[], object>>)scope;
+        public DependencyResolver(object scope)
+        {
+            _dependencies = (IDictionary<string, Func<object[], object>>)scope;
+        }
 
         public object Resolve(string dependency, object[] args)
         {
@@ -19,7 +22,7 @@
                 }
                 else
                 {
-                    dependencies = (IDictionary<string, Func<object[], object>>)(dependencies["IoC.Scope.Parent"](args));
+                    dependencies = (IDictionary<string, Func<object[], object>>)dependencies["IoC.Scope.Parent"](args);
                 }
             }
         }

--- a/appserver/scopes/InitCommand.cs
+++ b/appserver/scopes/InitCommand.cs
@@ -4,14 +4,14 @@ namespace AppServer.Scopes
 {
     public class InitCommand : ICommand
     {
-        internal static ThreadLocal<object> currentScopes = 
+        internal static ThreadLocal<object> currentScopes =
             new ThreadLocal<object>(true);
 
-        static ConcurrentDictionary<string, Func<object[], object>> rootScope = 
+        static ConcurrentDictionary<string, Func<object[], object>> rootScope =
             new ConcurrentDictionary<string, Func<object[], object>>();
-        
+
         static bool _alreadyExecutesScuccessfully = false;
-        public void Execute() 
+        public void Execute()
         {
             if (_alreadyExecutesScuccessfully)
                 return;
@@ -49,7 +49,7 @@ namespace AppServer.Scopes
                     {
                         var creatingScope = Ioc.Resolve<IDictionary<string, Func<object[], object>>>("IoC.Scope.Create.Empty");
 
-                        if(args.Length > 0)
+                        if (args.Length > 0)
                         {
                             var parentScope = args[0];
                             creatingScope.Add("IoC.Scope.Parent", (object[] args) => parentScope);

--- a/appserver/scopes/SetCurrentScopeCommand.cs
+++ b/appserver/scopes/SetCurrentScopeCommand.cs
@@ -4,7 +4,11 @@
     {
         object _scope;
 
-        public SetCurrentScopeCommand(object scope) => _scope = scope;
+        public SetCurrentScopeCommand(object scope)
+        {
+            _scope = scope;
+        }
+
         public void Execute()
         {
             InitCommand.currentScopes.Value = _scope;

--- a/appserver/server.tests/ProcessorTests.cs
+++ b/appserver/server.tests/ProcessorTests.cs
@@ -1,5 +1,4 @@
 using Moq;
-using AppServer.Scopes;
 using System.Collections.Concurrent;
 
 namespace AppServer.Commands.Tests

--- a/appserver/server/RegisterProcessorCommand.cs
+++ b/appserver/server/RegisterProcessorCommand.cs
@@ -9,7 +9,6 @@
                 IDictionary<string, object> context = new Dictionary<string, object>();
                 new InitProcessorContextCommand(context).Execute();
                 context.Add("processor", new Processor(new Processable(context)));
-                new Processor(new Processable(context));
                 return context;
             }).Execute();
         }


### PR DESCRIPTION
Испрален баг с созданием двух процессоров, которые читают из одной очереди. В итоге тест, в некоторых случаях не проходил, так как два процессора читали ссобщения из одно очереди, при этом тест мог успешно завершитьься, только первый созlанный процессор получал сообщение HardStopCommand, а при работе двух процессоров иногда HardStopCommand ухождило в другой процессор.